### PR TITLE
Changed directory names

### DIFF
--- a/.github/workflows/data-product-example-2-upload.yaml
+++ b/.github/workflows/data-product-example-2-upload.yaml
@@ -43,5 +43,5 @@ jobs:
         env:
           BUCKET_NAME: data-platform-products-development20230412155038755500000001
         run: |
-          aws s3 sync . s3://$BUCKET_NAME/code/_example_2/ \
+          aws s3 sync . s3://$BUCKET_NAME/code_zips/_example_2/$(date +%Y%m%d%H%M%S)/ \
             --exclude '*' --include 'data_product_example_2.zip'


### PR DESCRIPTION
Cloudwatch triggers are a bit tricky, so we need to have the zips in a separate folder. Also re-add an extraction timestamp