### PR TITLE
remove underscore

### DIFF
--- a/data-products/example_2/package_data_product.py
+++ b/data-products/example_2/package_data_product.py
@@ -21,7 +21,7 @@ def zip_data_product(folder: str):
 
 
 def main():
-    zip_data_product("_example_2")
+    zip_data_product("example_2")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
missed this when renaming `example_2`, needed to test end-to-end dev product